### PR TITLE
Stage hunspell instead of depending on content snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -86,10 +86,6 @@ plugs:
   etc-firefox-policies:
     interface: system-files
     read: [/etc/firefox/policies]
-  hunspell-dictionaries:
-    interface: content
-    default-provider: hunspell-dictionaries-1-7-2004
-    target: $SNAP/usr/share/hunspell
   host-hunspell:
     interface: mount-control
     mount:
@@ -197,6 +193,26 @@ parts:
         cp target/release/dump_syms $SNAPCRAFT_STAGE/usr/bin/
       fi
 
+  #This is a temporary workaround to including the hunspell content snap,
+  #which would cause breakage in the Ubuntu desktop image build because of
+  #the Ubuntu policy. See https://bugzilla.mozilla.org/show_bug.cgi?id=1792006.
+  #
+  #The definition of this part is essentially a copy of the corresponding part
+  #in hunspell-dictionaries-1-7-2004 by Buo-ren, Lin.
+  hunspell:
+    plugin: nil
+    override-build: |
+      set -eu
+      apt download $(apt-cache search '^hunspell-.*$' |
+        awk '!/myspell|dbgsym|tools|transitional|dependency/{printf "%s ", $1}')
+      find . -name "*.deb" -exec dpkg-deb -x {} "$SNAPCRAFT_PART_INSTALL" \;
+    filesets:
+      hunspell-dictionaries: [usr/share/hunspell]
+    stage:
+      - $hunspell-dictionaries
+    prime:
+      - $hunspell-dictionaries
+
   wasi-sdk:
     plugin: nil
     after:
@@ -261,6 +277,7 @@ parts:
       - dump-syms
       - ffmpeg
       - firefox-langpacks
+      - hunspell
       - mozconfig
       - nodejs
       - pipewire


### PR DESCRIPTION
Dependency on the hunspell-dictionaries-1-7-2004 content snap breaks building Ubuntu desktop images.

Refer to https://bugzilla.mozilla.org/show_bug.cgi?id=1792006