### PR TITLE
Add LIBTHAI_DICTDIR environment

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,6 +21,7 @@ apps:
       PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"
       PIPEWIRE_MODULE_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pipewire-0.3"
       SPA_PLUGIN_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/spa-0.2"
+      LIBTHAI_DICTDIR: "$SNAP/usr/share/libthai/"
     slots:
       - dbus-daemon
       - mpris


### PR DESCRIPTION
From https://forum.snapcraft.io/t/thai-word-breaking-doesnt-work-in-snaps-using-common-gnome-snaps-e-g-firefox/32303, I found the firefox snap don't has LIBTHAI_DICTDIR environment.