### PR TITLE
Don't include libva but use the gnome sdk version instead

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -537,9 +537,6 @@ parts:
       - usr/lib/*/libtheoradec.so.*
       - usr/lib/*/libtheoraenc.so.*
       - usr/lib/*/libtwolame.so.*
-      - usr/lib/*/libva-drm.so.*
-      - usr/lib/*/libva.so.*
-      - usr/lib/*/libva-x11.so.*
       - usr/lib/*/libvdpau.so.*
       - usr/lib/*/libvpx.so.*
       - usr/lib/*/libwavpack.so.*


### PR DESCRIPTION
The library version needs to match the intel media driver one