### PR TITLE
Bug 1860702 - Use LLD and no LTO=cross

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -361,7 +361,7 @@ parts:
         # Enable LTO and PGO (https://firefox-source-docs.mozilla.org/build/buildsystem/pgo.html) only on amd64 for now.
         # Linking with gold fails on armhf (error: undefined reference to '__aeabi_uldivmod') and would need to be
         # investigated further, and running PGO on arm64 takes forever (> 4 days in the Launchpad build environment!).
-        echo "ac_add_options --enable-linker=gold" >> $MOZCONFIG
+        echo "ac_add_options --enable-linker=lld" >> $MOZCONFIG
         echo "ac_add_options MOZ_PGO=1" >> $MOZCONFIG
       fi
       if [ $CRAFT_TARGET_ARCH != "armhf" ]; then


### PR DESCRIPTION
Since we did the change on nightly and now nightly has moved to beta, we need it there as well.
Build is passing on PGO: https://treeherder.mozilla.org/jobs?repo=try&author=alissy%40mozilla.com&selectedTaskRun=GL9FKCMyTBaq32wgYJB04Q.0