### PR TITLE
Bug 1864243 - Use alsa plug to interact with MIDI devices

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,6 +40,7 @@ apps:
       - dbus-daemon
       - mpris
     plugs:
+      - alsa
       - audio-playback
       - audio-record
       - avahi-observe

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -113,6 +113,8 @@ plugs:
 layout:
   /usr/share/libdrm:
     bind: $SNAP/gnome-platform/usr/share/libdrm
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
 
 parts:
   rust:


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1864243

Firefox implementation of WebMIDI API requires ALSA in order to interact with MIDI devices.
