### PR TITLE
Use alsa plug to interact with MIDI devices

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,6 +40,7 @@ apps:
       - dbus-daemon
       - mpris
     plugs:
+      - alsa
       - audio-playback
       - audio-record
       - avahi-observe
@@ -112,6 +113,8 @@ plugs:
 layout:
   /usr/share/libdrm:
     bind: $SNAP/gnome-platform/usr/share/libdrm
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
 
 parts:
   rust:
@@ -434,6 +437,7 @@ parts:
       mkdir $CRAFT_PART_INSTALL/{gnome-platform,data-dir,data-dir/{icons,sounds,themes}}
       craftctl default
     stage-packages:
+      - libasound2
       - libcurl4
       - libpci3
       - libpipewire-0.3-0
@@ -472,6 +476,7 @@ parts:
       - usr/lib/*/libXt.so.*
       - usr/lib/*/pipewire-*
       - usr/lib/*/spa-*
+      - usr/share/alsa
       - usr/share/pipewire
       # Workaround for LP: #2016358 (see the 'override-stage' above).
       - gnome-platform


### PR DESCRIPTION
Firefox implementation of WebMIDI API requires ALSA in order to interact with MIDI devices.

Thanks Nikolaos for working on those changes