### PR TITLE
fix connect-plug-host-hunspell for non-classic systems

### DIFF
--- a/snap/hooks/connect-plug-host-hunspell
+++ b/snap/hooks/connect-plug-host-hunspell
@@ -1,4 +1,6 @@
 #!/bin/sh
 
 mkdir -p $SNAP_COMMON/host-hunspell
-snapctl mount --persistent -o ro,bind,noatime,noexec /usr/share/hunspell $SNAP_COMMON/host-hunspell
+if [ -d "/usr/share/hunspell" ]; then
+  snapctl mount --persistent -o ro,bind,noatime,noexec /usr/share/hunspell $SNAP_COMMON/host-hunspell
+fi


### PR DESCRIPTION
add existence test for /usr/share/hunspell before mounting, as this directory does not exist on non-classic systems like uc22 on rpi4b.

Not tested on classic system to see if still works.