### PR TITLE
snap, hooks: make host-hunspell a system-files interface

### DIFF
--- a/snap/hooks/connect-plug-host-hunspell
+++ b/snap/hooks/connect-plug-host-hunspell
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mkdir -p $SNAP_COMMON/host-hunspell
-snapctl mount --persistent -o ro,bind,noatime,noexec /usr/share/hunspell $SNAP_COMMON/host-hunspell

--- a/snap/hooks/disconnect-plug-host-hunspell
+++ b/snap/hooks/disconnect-plug-host-hunspell
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+# Clean up old Firefox snap mount for host hunspell; we now use
+# the system-files interface for host hunspell dictionaries.
+
+# TODO: Drop this (along with the host-hunspell mount-control
+# declaration in snapcraft.yaml) later in the future once a
+# reasonable amount of time has passed and nearly all users
+# have an updated version and were migrated to use system-files,
+# and just about no new Ubuntu installations start with a
+# Firefox snap that has the older mount-control interface.
 snapctl umount $SNAP_COMMON/host-hunspell || true
+rm -r $SNAP_COMMON/host-hunspell || true

--- a/snap/hooks/disconnect-plug-host-hunspell
+++ b/snap/hooks/disconnect-plug-host-hunspell
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-snapctl umount $SNAP_COMMON/host-hunspell || true

--- a/snap/hooks/disconnect-plug-host-hunspell
+++ b/snap/hooks/disconnect-plug-host-hunspell
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl umount $SNAP_COMMON/host-hunspell || true

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -14,23 +14,43 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-if [ ! -d $SNAP_COMMON/host-hunspell ]; then
-  echo "No host-hunspell, skipping"
-  exit 0
-fi;
+host_hunspell=/var/lib/snapd/hostfs/usr/share/hunspell
+
+if [ ! -d  $host_hunspell ]; then
+    echo "No host hunspell, skipping"
+    exit 0
+fi
+
 DICPATH=$SNAP_COMMON/snap-hunspell
 
 if [ -d $DICPATH ]; then
-  # Cleanup on each refresh, ensure we have uptodate content
-  find $DICPATH -type l -name "*.dic" -or -name "*.aff" | xargs rm
+    # Clean up on each refresh to ensure we have an up-to-date list
+    # of host dictionaries.
+    find $DICPATH -type l -name "*.dic" -or -name "*.aff" | xargs rm
 else
-  mkdir -p $DICPATH
+    mkdir -p $DICPATH
 fi
 
-for dic in $(find $SNAP_COMMON/host-hunspell/ -name "*.dic");
-do
-  dic_file=$(basename $dic)
-  aff_file="${dic_file%%.dic}.aff"
-  ln -s $SNAP/usr/share/hunspell/${dic_file} $DICPATH/${dic_file}
-  ln -s $SNAP/usr/share/hunspell/${aff_file} $DICPATH/${aff_file}
-done;
+# We deliberately don't directly use the host dictionary files.
+# Instead, we use their names to know which ones the user has
+# installed on their system, and we use the corresponding ones
+# we primed in '$SNAP/usr/share/hunspell' in our 'hunspell' part.
+#
+# - We don't set DICPATH=/var/lib/snapd/hostfs/usr/share/hunspell
+#   to avoid potential incompatibility due to different hunspell
+#   versions inside the snap and outside on the host.  See:
+#   https://github.com/snapcore/snapd/pull/11025
+#
+# - We don't set DICPATH="$SNAP/usr/share/hunspell" because that
+#   would result in all available dictionaries we primed in our
+#   'hunspell' part being displayed in Firefox's interface,
+#   presenting an overwhelming number of options to the user.
+#   So instead we only use those that were installed on the host.
+#   This way, the user could affect the dictionaries available to
+#   Firefox snap similarly to how they could for non-snap Firefox.
+for dic in $(find $host_hunspell/ -name "*.dic"); do
+    dic_file=$(basename $dic)
+    aff_file="${dic_file%%.dic}.aff"
+    ln -s $SNAP/usr/share/hunspell/${dic_file} $DICPATH/${dic_file}
+    ln -s $SNAP/usr/share/hunspell/${aff_file} $DICPATH/${aff_file}
+done

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,7 +29,9 @@ apps:
     desktop: firefox.desktop
     extensions: [gnome]
     environment:
-      DICPATH: "/var/lib/snapd/hostfs/usr/share/hunspell"
+      # See below and also the 'snap/hooks/post-refresh' file for
+      # more details about our hunspell setup.
+      DICPATH: "$SNAP_COMMON/snap-hunspell"
       GTK_USE_PORTAL: 1
       HOME: "$SNAP_USER_COMMON"
       PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
       - gsettings
       - hardware-observe
       - home
+      - host-hunspell
       - host-usr-share-hunspell
       - joystick
       - network
@@ -77,6 +78,7 @@ apps:
       - gsettings
       - hardware-observe
       - home
+      - host-hunspell
       - host-usr-share-hunspell
       - joystick
       - network
@@ -102,6 +104,13 @@ plugs:
   etc-firefox:
     interface: system-files
     read: [/etc/firefox]
+  host-hunspell:
+    interface: mount-control
+    mount:
+    - what: /usr/share/hunspell
+      where: $SNAP_COMMON/host-hunspell
+      persistent: true
+      options: [ro, bind, noatime, noexec]
   host-usr-share-hunspell:
     interface: system-files
     read:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -603,3 +603,7 @@ slots:
     interface: dbus
     bus: session
     name: org.mozilla.firefox
+
+hooks:
+  post-refresh:
+    plugs: [host-usr-share-hunspell]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,7 +29,7 @@ apps:
     desktop: firefox.desktop
     extensions: [gnome]
     environment:
-      DICPATH: "$SNAP_COMMON/snap-hunspell"
+      DICPATH: "/var/lib/snapd/hostfs/usr/share/hunspell"
       GTK_USE_PORTAL: 1
       HOME: "$SNAP_USER_COMMON"
       PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"
@@ -103,12 +103,9 @@ plugs:
     interface: system-files
     read: [/etc/firefox]
   host-hunspell:
-    interface: mount-control
-    mount:
-    - what: /usr/share/hunspell
-      where: $SNAP_COMMON/host-hunspell
-      persistent: true
-      options: [ro, bind, noatime, noexec]
+    interface: system-files
+    read:
+    - /var/lib/snapd/hostfs/usr/share/hunspell
 
 layout:
   /usr/share/libdrm:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,7 +50,7 @@ apps:
       - gsettings
       - hardware-observe
       - home
-      - host-hunspell
+      - host-usr-share-hunspell
       - joystick
       - network
       - network-observe
@@ -77,7 +77,7 @@ apps:
       - gsettings
       - hardware-observe
       - home
-      - host-hunspell
+      - host-usr-share-hunspell
       - joystick
       - network
       - network-observe
@@ -102,7 +102,7 @@ plugs:
   etc-firefox:
     interface: system-files
     read: [/etc/firefox]
-  host-hunspell:
+  host-usr-share-hunspell:
     interface: system-files
     read:
     - /var/lib/snapd/hostfs/usr/share/hunspell


### PR DESCRIPTION
The host-hunspell plug was a mount-control interface, which means that the snap could request snapd to set up a mount from/to a specific location. The problem is that the mount is visible in the host mount namespace, i.e. the mounts created a system wide. The mount-control interface was really intended to be used in Ubuntu Core oriented scenarios, when for instance a gadget mounts some external storage at a system wide location.

The particular case of the Firefox snap only really needs access to the hunspell dictionaries on the host. In this case a system-files interface allowing access to /usr/share/hunspell inside the host filesystem (exposed to the snap mount ns at /var/lib/snapd/hostfs) will be sufficient.

This will fix issues like LP#2059195