### PR TITLE
Add login-session-observe plug - LP: #2067564

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,6 +57,7 @@ apps:
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
+      - login-session-observe
       - network
       - network-observe
       - opengl
@@ -85,6 +86,7 @@ apps:
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
+      - login-session-observe
       - network
       - network-observe
       - opengl


### PR DESCRIPTION
Without it, the system log is flooded with AppArmor denials as Firefox tries to access the `org.freedesktop.DBus.Properties.PropertiesChanged` D-Bus signal.

[LP: #2067564](https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/2067564)