### PR TITLE
Bug 1899701 - Add home-read-all plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,7 +53,7 @@ apps:
       - cups-control
       - gsettings
       - hardware-observe
-      - home
+      - home-read-all
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
@@ -82,7 +82,7 @@ apps:
       - cups-control
       - gsettings
       - hardware-observe
-      - home
+      - home-read-all
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
@@ -121,6 +121,9 @@ plugs:
     interface: system-files
     read:
     - /var/lib/snapd/hostfs/usr/share/hunspell
+  home-read-all:
+    interface: home
+    read: all
 
 layout:
   /usr/share/libdrm:


### PR DESCRIPTION
Add a `home-read-all` plug that sets the `read` attribute for the `home` interface to the special value `all`, to allow the Firefox snap to read files in the user's home directory that are owned by another user but that the current user should still be able to read via group membership.

Note: `read: all` technically allows reading the home directory of any user, but per snapd folks that's as granular as we can get because AppArmor does not have per-user profiles.

@seb128 I tried your suggestion for a potential alternative workaround of opening the file using Firefox's open file dialog, and it failed the same way (Firefox doesn't seem to try to use the document portal).

@alexmurray would you please review this? I imagine I'd then need to submit a store request for a formal review/approval once we've merged this and uploaded a build with it to the store.

/cc @lissyx @zyga

https://bugzilla.mozilla.org/1899701
https://snapcraft.io/docs/home-interface