### PR TITLE
Set MOZ_APP_REMOTINGNAME to match the desktop file name

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,6 +40,7 @@ apps:
       SPA_PLUGIN_DIR: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/spa-0.2"
       SPEECHD_ADDRESS: "unix_socket:/run/user/$SNAP_UID/speech-dispatcher/speechd.sock"
       MOZ_DBUS_APP_NAME: "firefox_nightly"
+      MOZ_APP_REMOTINGNAME: "firefox_firefox"
     slots:
       - dbus-daemon
       - mpris


### PR DESCRIPTION
`MOZ_APP_REMOTINGNAME` is meant to match the desktop file name. The desktop file name of the snap is mangled by snapd to become firefox_firefox.desktop, so set `MOZ_APP_REMOTINGNAME=firefox_firefox`.
This fixes a bunch of issues:

## MPRIS icon
See also: https://forum.snapcraft.io/t/mpris-can-not-be-used-with-snaps/11119/9
![image](https://github.com/user-attachments/assets/095fac9e-6047-465d-9b0a-13548e505ca1)


## KDE Plasma Wayland taskbar.
When using `snap run firefox` from a terminal:
before:
![Screenshot_20240809_111942](https://github.com/user-attachments/assets/e56309af-4b27-4357-978c-56b7e584d975)
after:
![Screenshot_20240809_114712](https://github.com/user-attachments/assets/2d44f0a8-e896-491a-b377-57509c848919)


## KDE Plasma X11 taskbar.
When using `snap run firefox` from a terminal:
before:
![Screenshot_20240809_115509](https://github.com/user-attachments/assets/8fd0feda-2358-414a-af94-d31690a52fda)
after:
![Screenshot_20240809_114712](https://github.com/user-attachments/assets/2d44f0a8-e896-491a-b377-57509c848919)

Read https://github.com/canonical/firefox-snap/pull/74#discussion_r1711148679 for more details.