### PR TITLE
[Nightly] Add PCSCD interface for LP:1967632.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,6 +61,7 @@ apps:
       - network
       - network-observe
       - opengl
+      - pcscd
       - removable-media
       - screen-inhibit-control
       - system-packages-doc
@@ -90,6 +91,7 @@ apps:
       - network
       - network-observe
       - opengl
+      - pcscd
       - removable-media
       - screen-inhibit-control
       - system-packages-doc


### PR DESCRIPTION
Snapd has the PCSCD interface. Although it is apparently not sufficient to allow effortless smart card reading, it is a necessary step in that direction.

Even if incomplete, this change eliminates the problems we already know about from the bug reports, maybe uncover other useful errors to further track down this topic and also make a hacking-around-attempt less daunting, which might also provide useful insights.