### PR TITLE
[Nightly] Stage opensc-pkcs11.so.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -460,10 +460,13 @@ parts:
       - mesa-vulkan-drivers
       - pipewire-bin
       - pipewire-pulse
+      - opensc-pkcs11
     prime:
       - default256.png
       - firefox.desktop
       - usr/lib/firefox
+      - usr/lib/*/opensc-pkcs11.so
+      - usr/lib/*/pkcs11/opensc-pkcs11.so
       - usr/lib/*/libasn1.so.*
       - usr/lib/*/libcurl.so.*
       - usr/lib/*/libgssapi.so.*


### PR DESCRIPTION
Module required to access smart cards.

Should fix [LP:1967632](https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/1967632) or at least be one step in the direction.