### PR TITLE
Workaround $CRAFT_PARALLEL_BUILD_COUNT issue

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -188,7 +188,8 @@ parts:
         mkdir build
         cd build
         cmake -DLLVM_BINUTILS_INCDIR=/usr/include -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CRAFT_PART_INSTALL/usr ..
-        make -j$CRAFT_PARALLEL_BUILD_COUNT install-LLVMgold-stripped
+        # TODO: use $CRAFT_PARALLEL_BUILD_COUNT again once https://github.com/canonical/snapcraft/issues/4785 is fixed
+        make -j8 install-LLVMgold-stripped
       fi
     override-stage: |
       craftctl default
@@ -424,9 +425,11 @@ parts:
       $MACH repackage desktop-file --output $CRAFT_PART_INSTALL/firefox.desktop --flavor snap --release-product "firefox" --release-type nightly
       if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         # xvfb is only needed when doing a PGO-enabled build
-        xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build --verbose -j$CRAFT_PARALLEL_BUILD_COUNT
+        # TODO: use $CRAFT_PARALLEL_BUILD_COUNT again once https://github.com/canonical/snapcraft/issues/4785 is fixed
+        xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build --verbose -j8
       else
-        $MACH build --verbose -j$CRAFT_PARALLEL_BUILD_COUNT
+        # TODO: use $CRAFT_PARALLEL_BUILD_COUNT again once https://github.com/canonical/snapcraft/issues/4785 is fixed
+        $MACH build --verbose -j8
       fi
       find . -name 'dep-graph.bin' -delete
       find . -name 'query-cache.bin' -delete


### PR DESCRIPTION
Workaround https://github.com/canonical/snapcraft/issues/4785 where snapcraft set the parallel value to -j1, we will need to revert once the issue is resolved in snapcraft but meanwhile it should restore shorter builds in nightly (we can then cherry-pick to stable-core24 after confirming the value is working on the builders)