### PR TITLE
Cherry-pick 'Allow DRI/EGL path when running under Snap (with core24)'

### DIFF
--- a/patches/gpu-access.patch
+++ b/patches/gpu-access.patch
@@ -1,0 +1,45 @@
+# Allow DRI/EGL path when running under Snap (with core24)
+# https://phabricator.services.mozilla.com/D224222
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1921520
+diff --git a/security/sandbox/linux/broker/SandboxBrokerPolicyFactory.cpp b/security/sandbox/linux/broker/SandboxBrokerPolicyFactory.cpp
+
+--- a/security/sandbox/linux/broker/SandboxBrokerPolicyFactory.cpp
++++ b/security/sandbox/linux/broker/SandboxBrokerPolicyFactory.cpp
+@@ -404,10 +404,36 @@
+   // glvnd config:
+   if (const char* snapDesktopDir = PR_GetEnv("SNAP_DESKTOP_RUNTIME")) {
+     nsAutoCString snapDesktopShare(snapDesktopDir);
+     snapDesktopShare.AppendLiteral("/usr/share");
+     policy->AddDir(rdonly, snapDesktopShare.get());
++
++    // Introduced by Snap's core24 changes, and gpu-2404 snap package, this
++    // directory holds the drirc configuration
++    if (const char* drircConfigDir = PR_GetEnv("DRIRC_CONFIGDIR")) {
++      nsAutoCString drircConfigShare(drircConfigDir);
++      policy->AddDir(rdonly, drircConfigShare.get());
++    }
++
++    // Introduced by Snap's core24 changes, and gpu-2404 snap package, those egl
++    // environment variable configure where libraries are. Failing to access and
++    // load those will result in bug 1921520: RDD process will fail to create
++    // GLContext for VA-API, thus breaking hardware decoding and falling back to
++    // software decoding while generating (potentially a lot of) crash reports.
++
++    if (const char* eglExternalPlatformConfigDir =
++            PR_GetEnv("__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS")) {
++      nsAutoCString eglExternalPlatformConfigShare(
++          eglExternalPlatformConfigDir);
++      policy->AddDir(rdonly, eglExternalPlatformConfigShare.get());
++    }
++
++    if (const char* eglVendorLibraryDir =
++            PR_GetEnv("__EGL_VENDOR_LIBRARY_DIRS")) {
++      nsAutoCString eglVendorLibraryShare(eglVendorLibraryDir);
++      policy->AddDir(rdonly, eglVendorLibraryShare.get());
++    }
+   }
+ 
+   // Note: This function doesn't do anything about Mesa's shader
+   // cache, because the details can vary by process type, including
+   // whether caching is enabled.
+

--- a/patches/series
+++ b/patches/series
@@ -1,1 +1,2 @@
 native-messaging-portal.patch
+gpu-access.patch


### PR DESCRIPTION
Cherry picked the fix from https://phabricator.services.mozilla.com/D224222 which is expected to land upsteam to nightly but not to stable