### PR TITLE
Remove libdrm layout

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -125,8 +125,6 @@ plugs:
     - /var/lib/snapd/hostfs/usr/share/hunspell
 
 layout:
-  /usr/share/libdrm:
-    bind: $SNAP/gnome-platform/usr/share/libdrm
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/opensc-pkcs11.so:


### PR DESCRIPTION
Discussing with saviq on matrix, he pointed out this was not required and taken care of by https://github.com/canonical/snapcraft/blob/82fa41a2c80075bb851a5f0f046655571ec917cb/snapcraft/extensions/gnome.py#L150-L156