### PR TITLE
Set 'firefox' as the StartupWMClass hint in the desktop file.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -409,7 +409,7 @@ parts:
         export LD_LIBRARY_PATH="$CRAFT_PART_BUILD/obj-$TARGET_TRIPLET/instrumented/dist/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
       MACH="/usr/bin/python3 ./mach"
-      $MACH repackage desktop-file --output $CRAFT_PART_INSTALL/firefox.desktop --flavor snap --release-product "firefox" --release-type release
+      $MACH repackage desktop-file --output $CRAFT_PART_INSTALL/firefox.desktop --flavor snap --release-product "firefox" --release-type release --wmclass firefox_firefox
       if [ $CRAFT_TARGET_ARCH = "amd64" ]; then
         # xvfb is only needed when doing a PGO-enabled build
         xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build -j$CRAFT_PARALLEL_BUILD_COUNT


### PR DESCRIPTION
Upstream bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1924319

Do not merge before https://phabricator.services.mozilla.com/D228353 lands.