### PR TITLE
Bug 1930119 - Fix nativeMessaging regression in 133 (Beta)

### DIFF
--- a/patches/native-messaging-portal.patch
+++ b/patches/native-messaging-portal.patch
@@ -55,7 +55,7 @@ index b38571bb86536..fc6ca98f05dec 100644
 +#  - 2: auto (true for snap and flatpak or GTK_USE_PORTAL=1, false otherwise)
 +- name: widget.use-xdg-desktop-portal.native-messaging
 +  type: int32_t
-+  value: 0
++  value: 2
 +  mirror: always
 +
  # Whether to try to use XDG portal for settings / look-and-feel information.


### PR DESCRIPTION
The nativeMessaging feature in extensions depends on a portal, but the previous patch disabled the feature by default. This patch fixes the regression by enabling the feature by default if supported.

Fixes regression caused by #98.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1930119 for details.