### PR TITLE
snap: fix window name

### DIFF
--- a/firefox.launcher
+++ b/firefox.launcher
@@ -52,4 +52,4 @@ if [ ! -d "$DOTMOZILLA" ]; then
   fi
 fi
 
-exec "$SNAP/usr/lib/firefox/firefox" "$@"
+exec "$SNAP/usr/lib/firefox/firefox" --name firefox_firefox "$@"


### PR DESCRIPTION
This would fix kwin not showing icon for firefox snap as kwin will be able to find the correct desktop file.