### PR TITLE
Revert 'git push stable' back to 'git push'.

### DIFF
--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -44,7 +44,7 @@ jobs:
             git config user.name "GitHub Actions"
             git config user.email "actions@github.com"
             git commit -m "Bump version to the latest release candidate (${{ env.new_version }})."
-            git push stable
+            git push
           else
             echo "New major version (${{ env.new_version }}), please merge the beta branch into the stable one."
           fi


### PR DESCRIPTION
To address https://github.com/canonical/firefox-snap/pull/104#discussion_r1852785252.

I'll review all the differences between beta and stable in .github in a later merge request.