### PR TITLE
Add mount-observe plug for https://bugzilla.mozilla.org/1934713

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,6 +57,7 @@ apps:
       - host-usr-share-hunspell
       - joystick
       - login-session-observe
+      - mount-observe
       - network
       - network-observe
       - opengl


### PR DESCRIPTION
Silences syslog messages when spawning the file open dialog etc

Signed-off-by: Alex Murray <alex.murray@canonical.com>