### PR TITLE
Fix lack of spell checking for symlinked hunspell dictionaries

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,1 @@
+post-refresh

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -60,6 +60,10 @@ fi
 for dic in $(find $host_hunspell/ -name "*.dic"); do
     dic_file=$(basename $dic)
     aff_file="${dic_file%%.dic}.aff"
-    ln -s $SNAP/usr/share/hunspell/${dic_file} $DICPATH/${dic_file}
-    ln -s $SNAP/usr/share/hunspell/${aff_file} $DICPATH/${aff_file}
+    # Some dic,aff files in hunspell are themselves symlinks to other files,
+    # e.g. /usr/share/hunspell/fr_CH.dic -> fr.dic.
+    # That extra level of indirection somehow breaks spell checking.
+    # We therefore use readlink to link to the "real" file, not to a symlink.
+    ln -s "$(readlink -e $SNAP/usr/share/hunspell/${dic_file})" $DICPATH/${dic_file}
+    ln -s "$(readlink -e $SNAP/usr/share/hunspell/${aff_file})" $DICPATH/${aff_file}
 done


### PR DESCRIPTION
Firefox' `post-refresh` hook install symlinks in $SNAP_COMMON/snap-hunspell to the bundled dictionaries matching the host's ones. However some of those symlink targets are themselves symlinks. E.g., in my system:
```
% ls /var/snap/firefox/common/snap-hunspell/de_CH*
lrwxrwxrwx 1 root root 47 Jan  9 10:21 /var/snap/firefox/common/snap-hunspell/de_CH.aff -> /snap/firefox/5561/usr/share/hunspell/de_CH.aff
lrwxrwxrwx 1 root root 47 Jan  9 10:21 /var/snap/firefox/common/snap-hunspell/de_CH.dic -> /snap/firefox/5561/usr/share/hunspell/de_CH.dic
% ls /snap/firefox/current/usr/share/hunspell/de_CH*
lrwxrwxrwx 1 root root   15 Nov 18  2021 /snap/firefox/current/usr/share/hunspell/de_CH.aff -> de_CH_frami.aff
lrwxrwxrwx 1 root root   15 Nov 18  2021 /snap/firefox/current/usr/share/hunspell/de_CH.dic -> de_CH_frami.dic
-rw-r--r-- 1 root root  19K Aug 16  2021 /snap/firefox/current/usr/share/hunspell/de_CH_frami.aff
-rw-r--r-- 1 root root 4,2M Aug 16  2021 /snap/firefox/current/usr/share/hunspell/de_CH_frami.dic
```
For some reason, this causes the spell checking corresponding to that language to simply not function: Even though it is listed, all words are marked as incorrect:

![schw](https://github.com/user-attachments/assets/caade90b-365b-497e-9ff6-df7edfae5aff)

This fixes the issue, and also adds the `install` hook (as a mirror of `post-refresh`) while we're at it;