### PR TITLE
beta: Set MOZ_APP_REMOTINGNAME to match the desktop file name #74

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,6 +40,7 @@ apps:
       SPA_PLUGIN_DIR: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/spa-0.2"
       SPEECHD_ADDRESS: "unix_socket:/run/user/$SNAP_UID/speech-dispatcher/speechd.sock"
       MOZ_DBUS_APP_NAME: "firefox_beta"
+      MOZ_APP_REMOTINGNAME: "firefox_firefox"
     slots:
       - dbus-daemon
       - mpris


### PR DESCRIPTION
## cherry-picks fix #74 from nightly to beta

MOZ_APP_REMOTINGNAME is meant to match the desktop file name. The desktop file name of the snap is mangled by snapd to become firefox_firefox.desktop, so set MOZ_APP_REMOTINGNAME=firefox_firefox.

This fixes a bunch of issues:
* The MPRIS icon (https://forum.snapcraft.io/t/mpris-can-not-be-used-with-snaps/11119/9)
* The KDE Plasma Wayland taskbar (https://bugzilla.allizom.org/show_bug.cgi?id=1826330)
* The KDE Plasma X11 taskbar