### PR TITLE
Bump Rust to 1.82.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -138,7 +138,7 @@ parts:
       - wget
     override-pull: wget -O rustup.sh https://sh.rustup.rs
     override-build: |
-      REQUIRED_RUST_VERSION=1.76.0
+      REQUIRED_RUST_VERSION=1.82.0
       sh rustup.sh -q -y --default-toolchain $REQUIRED_RUST_VERSION
     override-prime: ''
 


### PR DESCRIPTION
Nightly [failed to build](https://launchpadlibrarian.net/778747635/buildlog_snap_ubuntu_noble_amd64_firefox-snap-nightly_BUILDING.txt.gz) with:
```
::  0:08.47 ERROR: Rust compiler 1.76.0 is too old.
```