### PR TITLE
Armhf: Fix failure to uncompress gz archive with --xz flag.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -182,7 +182,11 @@ parts:
       elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         BINARIES_SUFFIX=aarch64-linux-gnu.tar.xz
       fi
-      wget -O - $ROOT/$BINARIES_BASENAME-$BINARIES_SUFFIX | tar -x --xz
+      case "$BINARIES_SUFFIX" in
+        *gz) tar_flag="--gzip";;
+        *xz) tar_flag="--xz";;
+      esac
+      wget -O - $ROOT/$BINARIES_BASENAME-$BINARIES_SUFFIX | tar -x "$tar_flag"
       # And cmake-$LLVM_RELEASE.src needed on LLVM >= 15.0.0
       wget -O - $ROOT/cmake-$LLVM_RELEASE.src.tar.xz | tar -x --xz
       mv cmake-$LLVM_RELEASE.src cmake


### PR DESCRIPTION
Armhf build [failed](https://launchpadlibrarian.net/779080579/buildlog_snap_ubuntu_noble_armhf_firefox-snap-nightly_BUILDING.txt.gz):

```
:: + tar -x --xz
:: --2025-02-27 01:55:21--  https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-armv7a-linux-gnueabihf.tar.gz
:: Connecting to 10.10.10.1:8222... connected.
:: Proxy request sent, awaiting response... 302 Found
:: Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/75821432/c33eb0aa-a5b5-4c3f-aac1-78ec21c2fdca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250227%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250227T015522Z&X-Amz-Expires=300&X-Amz-Signature=15b6b1ddbd61b71f4ef05e295aa7fdb19fb4909a08467172867db8b17034896f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dclang%2Bllvm-17.0.6-armv7a-linux-gnueabihf.tar.gz&response-content-type=application%2Foctet-stream [following]
:: --2025-02-27 01:55:22--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/75821432/c33eb0aa-a5b5-4c3f-aac1-78ec21c2fdca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250227%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250227T015522Z&X-Amz-Expires=300&X-Amz-Signature=15b6b1ddbd61b71f4ef05e295aa7fdb19fb4909a08467172867db8b17034896f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dclang%2Bllvm-17.0.6-armv7a-linux-gnueabihf.tar.gz&response-content-type=application%2Foctet-stream
:: Connecting to 10.10.10.1:8222... connected.
:: Proxy request sent, awaiting response... 200 OK
:: Length: 1332555760 (1.2G) [application/octet-stream]
:: Saving to: ‘STDOUT’
::      0K .........xz: (stdin): File format not recognized
:: .tar: Child died with signal 13
:: tar: Error is not recoverable: exiting now
```

We forgot to uncompress with Gzip instead of Xz for Arhmf.

The simplest solution would be to save the archive to a file and then 'tar -x' could extract it without hinting to the archive's format, but we are getting out of space in the builders so I'm suggesting a more clumsy approach but keeping the pipe.