### PR TITLE
snapcraft.yaml: support rust riscv64 download

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -146,6 +146,8 @@ parts:
         BINARIES_SUFFIX=armv7-unknown-linux-gnueabihf
       elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         BINARIES_SUFFIX=aarch64-unknown-linux-gnu
+      elif [ $CRAFT_ARCH_BUILD_FOR = "riscv64" ]; then
+        BINARIES_SUFFIX=riscv64gc-unknown-linux-gnu
       fi
       wget -O - $ROOT-$BINARIES_SUFFIX.tar.gz | tar -x -z --strip-components=1
       ./install.sh --prefix=/usr --destdir=$CRAFT_STAGE


### PR DESCRIPTION
The rust part is build by downloading an upstream release.

Add the binary suffix for riscv64 so that we can download it once we move to building for riscv64.