### PR TITLE
Revert "Firefox Snap armhf/arm64 cross-compilation"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,30 +21,6 @@ grade: stable
 base: core24
 compression: lzo
 
-# This requires snapcraft version including
-# https://github.com/canonical/snapcraft/pull/5233
-
-# Launchpad is not able to handle those for the moment, so it is commented by
-# default but users can uncomment
-##CROSS-COMPILATION##platforms:
-##CROSS-COMPILATION##  native:
-##CROSS-COMPILATION##    build-on: [amd64]
-##CROSS-COMPILATION##    build-for: [amd64]
-##CROSS-COMPILATION##  cross-arm:
-##CROSS-COMPILATION##    build-on: [amd64, armhf]
-##CROSS-COMPILATION##    build-for: [armhf]
-##CROSS-COMPILATION##  cross-arm64:
-##CROSS-COMPILATION##    build-on: [amd64, arm64]
-##CROSS-COMPILATION##    build-for: [arm64]
-
-package-repositories:
-  - type: apt
-    architectures: [armhf, arm64]
-    components: [main, multiverse, universe]
-    suites: [noble, noble-updates, noble-security, noble-backports]
-    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-    url: http://ports.ubuntu.com/
-
 assumes:
   - snapd2.54 # for mount-control
 
@@ -166,37 +142,18 @@ parts:
     override-pull: |
       # Do not use rustup to work around https://forum.snapcraft.io/t/armhf-builds-on-launchpad-timing-out/31008
       REQUIRED_RUST_VERSION=1.82.0
-      RUST_PREFIX=rust-$REQUIRED_RUST_VERSION
-      STD_PREFIX=rust-std-$REQUIRED_RUST_VERSION
-      ROOT=https://static.rust-lang.org/dist/$RUST_PREFIX
-      ROOT_STD=https://static.rust-lang.org/dist/$STD_PREFIX
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      ROOT=https://static.rust-lang.org/dist/rust-$REQUIRED_RUST_VERSION
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         BINARIES_SUFFIX=x86_64-unknown-linux-gnu
-      elif [ $CRAFT_ARCH_BUILD_ON = "armhf" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
         BINARIES_SUFFIX=armv7-unknown-linux-gnueabihf
-      elif [ $CRAFT_ARCH_BUILD_ON = "arm64" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         BINARIES_SUFFIX=aarch64-unknown-linux-gnu
       elif [ $CRAFT_ARCH_BUILD_FOR = "riscv64" ]; then
         BINARIES_SUFFIX=riscv64gc-unknown-linux-gnu
       fi
-      wget -O - $ROOT-$BINARIES_SUFFIX.tar.gz | tar -x -z
-      pushd $RUST_PREFIX-$BINARIES_SUFFIX
-        ./install.sh --prefix=/usr --destdir=$CRAFT_STAGE
-      popd
-
-      if [ $CRAFT_ARCH_BUILD_ON != $CRAFT_ARCH_BUILD_FOR ]; then
-        if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
-          STD_BINARIES_SUFFIX=x86_64-unknown-linux-gnu
-        elif [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
-          STD_BINARIES_SUFFIX=thumbv7neon-unknown-linux-gnueabihf
-        elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
-          STD_BINARIES_SUFFIX=aarch64-unknown-linux-gnu
-        fi
-        wget -O - $ROOT_STD-$STD_BINARIES_SUFFIX.tar.gz | tar -x -z
-        pushd $STD_PREFIX-$STD_BINARIES_SUFFIX
-          ./install.sh --prefix=/usr --destdir=$CRAFT_STAGE
-        popd
-      fi
+      wget -O - $ROOT-$BINARIES_SUFFIX.tar.gz | tar -x -z --strip-components=1
+      ./install.sh --prefix=/usr --destdir=$CRAFT_STAGE
     override-prime: ''
 
   cbindgen:
@@ -223,11 +180,11 @@ parts:
       # Download the binaries
       # gnueabihf used to be tar.xz but at least 17.0.6 is not?
       BINARIES_BASENAME=clang+llvm-$LLVM_RELEASE
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         BINARIES_SUFFIX=x86_64-linux-gnu-ubuntu-22.04.tar.xz
-      elif [ $CRAFT_ARCH_BUILD_ON = "armhf" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
         BINARIES_SUFFIX=armv7a-linux-gnueabihf.tar.gz
-      elif [ $CRAFT_ARCH_BUILD_ON = "arm64" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         BINARIES_SUFFIX=aarch64-linux-gnu.tar.xz
       fi
       case "$BINARIES_SUFFIX" in
@@ -238,13 +195,13 @@ parts:
       # And cmake-$LLVM_RELEASE.src needed on LLVM >= 15.0.0
       wget -O - $ROOT/cmake-$LLVM_RELEASE.src.tar.xz | tar -x --xz
       mv cmake-$LLVM_RELEASE.src cmake
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         # And the sources to build LLVMgold.so, which isn't distributed in a binary form
         wget -O - $ROOT/llvm-$LLVM_RELEASE.src.tar.xz | tar -x --xz
       fi
     override-build: |
       craftctl default
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         cd llvm-$LLVM_RELEASE.src
         mkdir build
         cd build
@@ -268,7 +225,7 @@ parts:
       - jq
       - python3-yaml
     override-pull: |
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ] || [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         ROOT=https://ftp.mozilla.org/pub/firefox/nightly/latest-mozilla-central
         REVISION=$(wget -O - $ROOT/firefox-$(craftctl get version).en-US.linux-x86_64.txt | tail -1 | sed -n "s#^.*\/rev/\(.*\)\$#\1#p")
         FETCHES=https://hg.mozilla.org/mozilla-central/raw-file/${REVISION}/taskcluster/kinds/fetch/toolchains.yml
@@ -280,7 +237,7 @@ parts:
       fi
     override-build: |
       craftctl default
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ] || [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         $CRAFT_STAGE/usr/bin/cargo build --release
         mkdir -p $CRAFT_STAGE/usr/bin/
         cp target/release/dump_syms $CRAFT_STAGE/usr/bin/
@@ -334,11 +291,11 @@ parts:
       - NODEJS_RELEASE: "v18.12.1"
     override-pull: |
       ROOT=https://nodejs.org/dist/$NODEJS_RELEASE/node-$NODEJS_RELEASE-linux-
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         SUFFIX=x64.tar.xz
-      elif [ $CRAFT_ARCH_BUILD_ON = "armhf" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
         SUFFIX=armv7l.tar.xz
-      elif [ $CRAFT_ARCH_BUILD_ON = "arm64" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         SUFFIX=arm64.tar.xz
       fi
       wget -O - $ROOT$SUFFIX | tar -x --xz
@@ -378,57 +335,17 @@ parts:
       - rust
       - wasi-sdk
     build-packages:
-      - on amd64:
-        - to amd64:
-          - libasound2-dev
-          - libdbus-glib-1-dev
-          - libgtk-3-dev
-          - libgtk2.0-dev
-          - libpango1.0-dev
-          - libpulse-dev
-          - libpython3-dev
-          - libx11-xcb-dev
-          - libxkbcommon-dev
-          - libxt-dev
-        - to arm64:
-          - libstdc++-11-dev-arm64-cross
-          - libasound2-dev:arm64
-          - libdbus-glib-1-dev:arm64
-          - libgtk2.0-dev:arm64
-          - libgtk-3-dev:arm64
-          - libpango1.0-dev:arm64
-          - libpulse-dev:arm64
-          - libpython3-dev:arm64
-          - libx11-xcb-dev:arm64
-          - libxkbcommon-dev:arm64
-          - libxt-dev:arm64
-        - to armhf:
-          - libstdc++-11-dev-armhf-cross
-          - libasound2-dev:armhf
-          - libdbus-glib-1-dev:armhf
-          - libgtk2.0-dev:armhf
-          - libgtk-3-dev:armhf
-          - libpango1.0-dev:armhf
-          - libpulse-dev:armhf
-          - libpython3-dev:armhf
-          - libx11-xcb-dev:armhf
-          - libxkbcommon-dev:armhf
-          - libxt-dev:armhf
-      - else:
-        - libasound2-dev
-        - libdbus-glib-1-dev
-        - libgtk2.0-dev
-        - libgtk-3-dev
-        - libpango1.0-dev
-        - libpulse-dev
-        - libpython3-dev
-        - libx11-xcb-dev
-        - libxkbcommon-dev
-        - libxt-dev
       - cmake
       - coreutils
       - file
       - git
+      - libasound2-dev
+      - libdbus-glib-1-dev
+      - libgtk2.0-dev
+      - libgtk-3-dev
+      - libpython3-dev
+      - libx11-xcb-dev
+      - libxt-dev
       - m4
       - make
       - mercurial
@@ -452,7 +369,7 @@ parts:
       # easily rerun.
       QUILT_PATCHES=$CRAFT_PROJECT_DIR/patches quilt push -a
       BUILD_DBGSYMS=false
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ] || [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         # Build and publish debug symbols for amd64 and arm64 only,
         # because Launchpad builders for armhf choke (OOM) when
         # building with debug symbols enabled, even with
@@ -460,12 +377,15 @@ parts:
         # at least as of 2023-06-25.
         BUILD_DBGSYMS=true
       fi
-      # Too much debug info from Rust will make gkrust linkage fail on Launchpad
-      if [ $CRAFT_ARCH_BUILD_ON = "armhf" ] || [ $CRAFT_ARCH_BUILD_ON = "arm64" ]; then
+      # GitHub Actions is limited to 2 CPUs and 7GB RAM, and
+      # too much debug info from Rust will make gkrust linkage fail.
+      # Same goes for arm64 builds on Launchpad.  It seems we can't
+      # detect $GITHUB_WORKSPACE, so we assume presence of the file
+      # "symbols-upload-token" means we are running on GitHub.
+      if [ -f "$CRAFT_PROJECT_DIR/symbols-upload-token"] || [ $CRAFT_ARCH_BUILD_FOR = "arm64" ] || [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
         patch -p1 < $CRAFT_PROJECT_DIR/patches/mozilla-reduce-rust-debuginfo.patch
       fi
-      # Hardware is too limited on Launchpad so disabling LTO
-      if [ $CRAFT_ARCH_BUILD_ON = "armhf" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
         patch -p1 < $CRAFT_PROJECT_DIR/patches/armhf-thin-lto.patch
       fi
       export MOZCONFIG="$CRAFT_STAGE/mozconfig"
@@ -483,49 +403,30 @@ parts:
         echo "ac_add_options --enable-linker=lld" >> $MOZCONFIG
         echo "ac_add_options MOZ_PGO=1" >> $MOZCONFIG
       fi
-      # TODO: Revisit?
-      if [ $CRAFT_ARCH_BUILD_ON != "armhf" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR != "armhf" ]; then
         echo "ac_add_options --enable-rust-simd" >> $MOZCONFIG
       fi
       echo "ac_add_options --prefix=$CRAFT_PART_INSTALL/usr" >> $MOZCONFIG
-      if [ $CRAFT_ARCH_BUILD_ON != $CRAFT_ARCH_BUILD_FOR ]; then
-        if [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
-          echo "ac_add_options --target=aarch64-linux-gnu" >> $MOZCONFIG
-          echo "ac_add_options --enable-linker=lld" >> $MOZCONFIG
-        fi
-        if [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
-          echo "ac_add_options --target=arm-linux-gnueabihf" >> $MOZCONFIG
-          echo "ac_add_options --with-thumb=yes" >> $MOZCONFIG
-          echo "ac_add_options --with-arch=armv7" >> $MOZCONFIG
-          echo "ac_add_options --with-fpu=neon" >> $MOZCONFIG
-          echo "ac_add_options --enable-linker=lld" >> $MOZCONFIG
-        fi
-      fi
     override-build: |
       craftctl default
       export PATH=$CRAFT_STAGE/usr/bin/:$PATH
-      GNOME_SDK_SNAP_BASE=gnome-46-2404-sdk
-      GNOME_SDK_SNAP_REVISION=current
-      GNOME_SDK_SNAP=/snap/$GNOME_SDK_SNAP_BASE/$GNOME_SDK_SNAP_REVISION
+      GNOME_SDK_SNAP=/snap/gnome-46-2404-sdk/current
       if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         # "clang -dumpmachine" returns "x86_64-unknown-linux-gnu" on
         # amd64 (at least the binaries they distribute), but what we
         # really need is "x86_64-pc-linux-gnu"; so let's hard-code it.
         export TARGET_TRIPLET="x86_64-pc-linux-gnu"
-      elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
-        export TARGET_TRIPLET="aarch64-unknown-linux-gnu"
-      elif [ $CRAFT_ARCH_BUILD_FOR = "armhf" ]; then
-        export TARGET_TRIPLET="arm-linux-gnueabihf"
+      else
+        export TARGET_TRIPLET=$(clang -dumpmachine)
       fi
-      export LDFLAGS="-Wl,-rpath-link=$GNOME_SDK_SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Wl,-rpath-link=$GNOME_SDK_SNAP/usr/lib -Wl,-rpath-link=/usr/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lib/"
+      export LDFLAGS="-Wl,-rpath-link=$GNOME_SDK_SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -Wl,-rpath-link=$GNOME_SDK_SNAP/usr/lib"
       export LDFLAGS="-Wl,-rpath-link=$CRAFT_PART_BUILD/obj-$TARGET_TRIPLET/dist/bin${LDFLAGS:+ $LDFLAGS}"
       export LD_LIBRARY_PATH="$CRAFT_PART_BUILD/obj-$TARGET_TRIPLET/dist/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-      export PKG_CONFIG_PATH=$GNOME_SDK_SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/:$GNOME_SDK_SNAP/usr/lib/pkgconfig/:$GNOME_SDK_SNAP/usr/share/pkgconfig/:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/
       export WASI_SYSROOT=$CRAFT_STAGE/wasi-sysroot
       export MOZBUILD_STATE_PATH=$CRAFT_PART_BUILD/.mozbuild
       export MOZCONFIG="$CRAFT_STAGE/mozconfig"
       BUILD_DBGSYMS=false
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ] || [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
         # See override-pull above for why we only build debug symbols
         # on these arches.
         BUILD_DBGSYMS=true
@@ -548,7 +449,7 @@ parts:
 
       MACH="/usr/bin/python3 ./mach"
       $MACH repackage desktop-file --output $CRAFT_PART_INSTALL/firefox.desktop --flavor snap --release-product "firefox" --release-type nightly
-      if [ $CRAFT_ARCH_BUILD_ON = "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
         # xvfb is only needed when doing a PGO-enabled build
         # TODO: use $CRAFT_PARALLEL_BUILD_COUNT again once https://github.com/canonical/snapcraft/issues/4785 is fixed
         xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build --verbose -j$(nproc)
@@ -579,90 +480,52 @@ parts:
       mkdir $CRAFT_PART_INSTALL/{gnome-platform,data-dir,data-dir/{icons,sounds,themes}}
       craftctl default
     stage-packages:
-      - on amd64:
-        - to amd64:
-          - libasound2t64
-          - libcurl4t64
-          - libpci3
-          - libpipewire-0.3-0t64
-          - libpipewire-0.3-modules
-          - libspa-0.2-modules
-          - libspeechd2
-          - libvulkan1
-          - libxt6t64
-          - mesa-vulkan-drivers
-          - opensc-pkcs11
-        - to arm64:
-          - libasound2t64:arm64
-          - libcurl4t64:arm64
-          - libpci3:arm64
-          - libpipewire-0.3-0t64:arm64
-          - libpipewire-0.3-modules:arm64
-          - libspa-0.2-modules:arm64
-          - libspeechd2:arm64
-          - libvulkan1:arm64
-          - libxt6t64:arm64
-          - mesa-vulkan-drivers:arm64
-          - opensc-pkcs11:arm64
-        - to armhf:
-          - libasound2t64:armhf
-          - libcurl4t64:armhf
-          - libpci3:armhf
-          - libpipewire-0.3-0t64:armhf
-          - libpipewire-0.3-modules:armhf
-          - libspa-0.2-modules:armhf
-          - libspeechd2:armhf
-          - libvulkan1:armhf
-          - libxt6t64:armhf
-          - mesa-vulkan-drivers:armhf
-          - opensc-pkcs11:armhf
-      - else:
-        - libasound2t64
-        - libcurl4t64
-        - libpci3
-        - libpipewire-0.3-0t64
-        - libpipewire-0.3-modules
-        - libspa-0.2-modules
-        - libspeechd2
-        - libvulkan1
-        - libxt6t64
-        - mesa-vulkan-drivers
-        - opensc-pkcs11
+      - libasound2t64
+      - libcurl4t64
+      - libpci3
+      - libpipewire-0.3-0t64
+      - libpipewire-0.3-modules
+      - libspa-0.2-modules
+      - libspeechd2
+      - libvulkan1
+      - libxt6t64
+      - mesa-vulkan-drivers
       - pipewire-bin
       - pipewire-pulse
+      - opensc-pkcs11
     prime:
       - default256.png
       - firefox.desktop
       - usr/lib/firefox
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/opensc-pkcs11.so
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkcs11/opensc-pkcs11.so
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasn1.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcurl.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgssapi.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhcrypto.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libheimbase.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libheimntlm.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhogweed.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhx509.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libkrb5.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/liblber-2.4.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libldap_r-2.4.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnettle.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnghttp2.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpci.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpipewire*.so*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libroken.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/librtmp.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsasl2.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libspeechd.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libssh.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libssl.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libVkLayer*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwind.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXt.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pipewire-*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/spa-*
+      - usr/lib/*/opensc-pkcs11.so
+      - usr/lib/*/pkcs11/opensc-pkcs11.so
+      - usr/lib/*/libasn1.so.*
+      - usr/lib/*/libcurl.so.*
+      - usr/lib/*/libgssapi.so.*
+      - usr/lib/*/libhcrypto.so.*
+      - usr/lib/*/libheimbase.so.*
+      - usr/lib/*/libheimntlm.so.*
+      - usr/lib/*/libhogweed.so.*
+      - usr/lib/*/libhx509.so.*
+      - usr/lib/*/libkrb5.so.*
+      - usr/lib/*/liblber-2.4.so.*
+      - usr/lib/*/libldap_r-2.4.so.*
+      - usr/lib/*/libnettle.so.*
+      - usr/lib/*/libnghttp2.so.*
+      - usr/lib/*/libpci.so.*
+      - usr/lib/*/libpipewire*.so*
+      - usr/lib/*/libroken.so.*
+      - usr/lib/*/librtmp.so.*
+      - usr/lib/*/libsasl2.so.*
+      - usr/lib/*/libspeechd.so.*
+      - usr/lib/*/libssh.so.*
+      - usr/lib/*/libssl.so.*
+      - usr/lib/*/libvulkan*
+      - usr/lib/*/libVkLayer*
+      - usr/lib/*/libwind.so.*
+      - usr/lib/*/libXt.so.*
+      - usr/lib/*/pipewire-*
+      - usr/lib/*/spa-*
       - usr/share/alsa
       - usr/share/pipewire
       - usr/share/vulkan
@@ -714,66 +577,52 @@ parts:
     # Not using the ffmpeg snap (which might provide a more recent version)
     # because it is currently built on core18
     stage-packages:
-      - on amd64:
-        - to amd64:
-          - libavcodec60
-          - libhwy1t64
-          - libsvtav1enc1d1
-          - libjxl0.7
-          - librav1e0
-          - libvpl2 # the package is intel specific
-        - to arm64:
-          - libavcodec60:arm64
-          - libhwy1t64:arm64
-          - libsvtav1enc1d1:arm64
-          - libjxl0.7:arm64
-          - librav1e0:arm64
-        - to armhf:
-          - libavcodec60:armhf
-          - libhwy1t64:armhf
-          - libsvtav1enc1d1:armhf
-          - libjxl0.7:armhf
-          - librav1e0:armhf
-      - else:
-        - libavcodec60
-        - libhwy1t64
-        - libsvtav1enc1d1
-        - libjxl0.7
-        - librav1e0
-    prime:
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libaom.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libavcodec.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libavutil.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcodec2.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdav1d.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgsm.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmd.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmfx.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmp3lame.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnuma.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libOpenCL.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libopus.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libshine.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsnappy.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsoxr.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libspeex.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libswresample.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtheoradec.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtheoraenc.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtwolame.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvdpau.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvpx.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwavpack.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpmux.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebp.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libx264.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libx265.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxvidcore.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libzvbi.so.*
+      - libavcodec60
+      - libhwy1t64
+      - libsvtav1enc1d1
+      - libjxl0.7
+      - librav1e0
       # the package is intel specific
       - on amd64:
-        - to amd64:
-          - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvpl.so.*
+        - libvpl2
+    prime:
+      - usr/lib/*/libaom.so.*
+      - usr/lib/*/libavcodec.so.*
+      - usr/lib/*/libavutil.so.*
+      - usr/lib/*/libcodec2.so.*
+      - usr/lib/*/libdav1d.so.*
+      - usr/lib/*/libgsm.so.*
+      - usr/lib/*/libhwy.so.*
+      - usr/lib/*/libjxl.so.*
+      - usr/lib/*/libjxl_threads.so.*
+      - usr/lib/*/libmd.so.*
+      - usr/lib/*/libmfx.so.*
+      - usr/lib/*/libmp3lame.so.*
+      - usr/lib/*/libnuma.so.*
+      - usr/lib/*/libOpenCL.so.*
+      - usr/lib/*/libopus.so.*
+      - usr/lib/*/librav1e.so.*
+      - usr/lib/*/libshine.so.*
+      - usr/lib/*/libsnappy.so.*
+      - usr/lib/*/libsoxr.so.*
+      - usr/lib/*/libspeex.so.*
+      - usr/lib/*/libSvtAv1Enc.so.*
+      - usr/lib/*/libswresample.so.*
+      - usr/lib/*/libtheoradec.so.*
+      - usr/lib/*/libtheoraenc.so.*
+      - usr/lib/*/libtwolame.so.*
+      - usr/lib/*/libvdpau.so.*
+      - usr/lib/*/libvpx.so.*
+      - usr/lib/*/libwavpack.so.*
+      - usr/lib/*/libwebpmux.so.*
+      - usr/lib/*/libwebp.so.*
+      - usr/lib/*/libx264.so.*
+      - usr/lib/*/libx265.so.*
+      - usr/lib/*/libxvidcore.so.*
+      - usr/lib/*/libzvbi.so.*
+      # the package is intel specific
+      - on amd64:
+        - usr/lib/*/libvpl.so.*
 
   apikeys:
     plugin: nil
@@ -803,7 +652,16 @@ parts:
     override-build: |
       export SYMBOLS_ARCHIVE=$(find $CRAFT_STAGE/debug-symbols/ -type f -name "firefox-*.crashreporter-symbols.zip")
       if [ -f "$SYMBOLS_ARCHIVE" ]; then
-        cp $SYMBOLS_ARCHIVE $CRAFT_PROJECT_DIR/$CRAFT_PROJECT_NAME_$(craftctl get version)_$CRAFT_ARCH_BUILD_FOR.debug
+        if [ -f "$CRAFT_PROJECT_DIR/symbols-upload-token" ]; then
+          virtualenv venv/
+          source venv/bin/activate
+          venv/bin/pip3 install redo requests argparse
+          SOCORRO_SYMBOL_UPLOAD_URL=https://symbols.mozilla.org/upload/ SOCORRO_SYMBOL_UPLOAD_TOKEN_FILE="$CRAFT_PROJECT_DIR/symbols-upload-token" venv/bin/python3 $CRAFT_STAGE/debug-symbols/upload_symbols.py $SYMBOLS_ARCHIVE
+          rm "$CRAFT_PROJECT_DIR/symbols-upload-token"
+          deactivate
+        else
+          cp $SYMBOLS_ARCHIVE $CRAFT_PROJECT_DIR/$CRAFT_PROJECT_NAME_$(craftctl get version)_$CRAFT_ARCH_BUILD_FOR.debug
+        fi
       fi
 
 slots:


### PR DESCRIPTION
This reverts commit e806c2dbf18c0c0133100c94ecaf9957bc3242df.

This broke https://bugzilla.mozilla.org/show_bug.cgi?id=1958430 and I think it also broke debug symbols on arm builds outside of cross-compilation