### PR TITLE
[Nightly] Revert parallelism reduction in Launchpad.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -539,15 +539,8 @@ parts:
       MACH="/usr/bin/python3 ./mach"
       $MACH repackage desktop-file --output $CRAFT_PART_INSTALL/firefox.desktop --flavor snap --release-product "firefox" --release-type nightly
       if grep -qF "MOZ_PGO=1" "$MOZCONFIG"; then
-        # Builds get OOM way too often in Launchpad while compiling gkrust,
-        # so reduce parallelism in Launchpad.
-        if snap info snapcraft | grep 'tracking:.*launchpad-buildd'; then
-          n_parallel_jobs=1
-        else
-          n_parallel_jobs=$CRAFT_PARALLEL_BUILD_COUNT
-        fi
         # xvfb is only needed when doing a PGO-enabled build
-        xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build --verbose -j$n_parallel_jobs
+        xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build --verbose -j$CRAFT_PARALLEL_BUILD_COUNT
       else
         $MACH build --verbose -j$CRAFT_PARALLEL_BUILD_COUNT
       fi


### PR DESCRIPTION
Reverts:

43ae241 Logging: Non-silently grep launchpad-buildd channel. a02800a Remove parallelism of PGO build on Launchpad. 1de1da7 Merge pull request #129 from nteodosio/lp-less-parallelism 24448ef (norig/lp-less-parallelism) Reduce parallelism of PGO build on Launchpad.

It turned out that even with 1 job the build would still with the same frequency exhaust the 16 GB of memory available in Launchpad.