### PR TITLE
Bug 1962824 - Stage missing libs (as bug 1921018)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -735,21 +735,27 @@ parts:
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcodec2.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdav1d.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgsm.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhwy.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libjxl.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libjxl_threads.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmd.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmfx.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmp3lame.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnuma.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libOpenCL.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libopus.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/librav1e.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libshine.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsnappy.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsoxr.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libspeex.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libSvtAv1Enc.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libswresample.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtheoradec.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtheoraenc.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtwolame.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvdpau.so.*
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvpl.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvpx.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwavpack.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpmux.so.*


### PR DESCRIPTION
```
[task 2025-05-03T00:44:46.388Z] Lint warnings:
[task 2025-05-03T00:44:46.389Z] - library: usr/lib/x86_64-linux-gnu/libavcodec.so.60.31.102: missing dependency 'libSvtAv1Enc.so.1'. (provided by 'libsvtav1enc1d1') (https://snapcraft.io/docs/linters-library)
[task 2025-05-03T00:44:46.389Z] - library: usr/lib/x86_64-linux-gnu/libavcodec.so.60.31.102: missing dependency 'libhwy.so.1'. (provided by 'libhwy1t64') (https://snapcraft.io/docs/linters-library)
[task 2025-05-03T00:44:46.389Z] - library: usr/lib/x86_64-linux-gnu/libavcodec.so.60.31.102: missing dependency 'libjxl.so.0.7'. (provided by 'libjxl0.7') (https://snapcraft.io/docs/linters-library)
[task 2025-05-03T00:44:46.389Z] - library: usr/lib/x86_64-linux-gnu/libavcodec.so.60.31.102: missing dependency 'libjxl_threads.so.0.7'. (provided by 'libjxl0.7') (https://snapcraft.io/docs/linters-library)
[task 2025-05-03T00:44:46.389Z] - library: usr/lib/x86_64-linux-gnu/libavcodec.so.60.31.102: missing dependency 'librav1e.so.0'. (provided by 'librav1e0') (https://snapcraft.io/docs/linters-library)
```