### PR TITLE
[stable-core24] correct libdrm location for gnome-46-2404.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -127,7 +127,7 @@ plugs:
 
 layout:
   /usr/share/libdrm:
-    bind: $SNAP/gnome-platform/usr/share/libdrm
+    bind: $SNAP/gpu-2404/libdrm
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/opensc-pkcs11.so:
@@ -447,7 +447,7 @@ parts:
       # Workaround for LP: #2016358: create mount points for the gnome
       # content interface, while a proper fix is implemented in snapd.
       # Thanks to James Henstridge.
-      mkdir $CRAFT_PART_INSTALL/{gnome-platform,data-dir,data-dir/{icons,sounds,themes}}
+      mkdir $CRAFT_PART_INSTALL/{gpu-2404,data-dir,data-dir/{icons,sounds,themes}}
       craftctl default
     stage-packages:
       - libasound2t64
@@ -500,7 +500,7 @@ parts:
       - usr/share/pipewire
       - usr/share/vulkan
       # Workaround for LP: #2016358 (see the 'override-stage' above).
-      - gnome-platform
+      - gpu-2404
       - data-dir/icons
       - data-dir/sounds
       - data-dir/themes

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -126,8 +126,6 @@ plugs:
     - /var/lib/snapd/hostfs/usr/share/hunspell
 
 layout:
-  /usr/share/libdrm:
-    bind: $SNAP/gpu-2404/libdrm
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/opensc-pkcs11.so:


### PR DESCRIPTION
This is the same fix for beta-core24, #133, applied to stable-core24.

/usr/share/libdrm was provided in the gnome-42-2204 snap, but it is not provided in the gnome-46-2404 snap. It is in the mesa-2404 snap. It is also in the core24 snap.

This PR corrects the layout for /usr/share/libdrm so that amdgpu.ids can be found. With this change the layout works:

> $ snap run --shell firefox -c "ls -l /usr/share/libdrm"
total 19
-rw-r--r-- 1 root root 19045 Jun 26  2024 amdgpu.ids
