### PR TITLE
CI: Do not warn about new ESR version that already has a branch (attempt 2); Be verbose; Add job for esr-140.

### DIFF
--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -86,7 +86,7 @@ jobs:
             git commit -m "Bump version to the latest ESR release (${{ env.new_version }})."
             git push
           # Only warn about new ESR major version if such an esr-{version} branch does not exist
-          elif ! git rev-parse -q --verify "esr-$new_esr_major_version"; then
+          elif ! git show-ref "esr-$new_esr_major_version"; then
             # We don't want this spamming the Mattermost channel, so just allow
             # it to send messages between 10:00 and 11:00.
             if [ "$(date +%H)" = 10 ]; then

--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -56,11 +56,14 @@ jobs:
             fi
           fi
   check-new-esr:
+    strategy:
+      matrix:
+        esr-branch: [esr, esr-140]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: esr
+          ref: ${{ matrix.esr-branch }}
       - name: Extract current version
         run: ./.github/scripts/extract-current-version.sh
       - name: Install python deps

--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Update snapcraft.yaml with the new version
         if: env.new_version
         run: |
+          set -x
           if [ $(echo ${{ env.current_version }} | cut -d. -f1) = $(echo ${{ env.new_version }} | cut -d. -f1) ]; then
             sed -i "s/^version: \"\(.*\)\"$/version: \"${{ env.new_version }}\"/" snapcraft.yaml
             git add snapcraft.yaml
@@ -71,6 +72,7 @@ jobs:
       - name: Update snapcraft.yaml with the new version
         if: env.new_version
         run: |
+          set -x
           current_esr_major_version=$(echo ${{ env.current_version }} | cut -d. -f1)
           new_esr_major_version=$(echo ${{ env.new_version }} | cut -d. -f1)
           if [ "$current_esr_major_version" = "$new_esr_major_version" ]; then


### PR DESCRIPTION
[Job](https://github.com/nteodosio/firefox-snap/actions/runs/15853687557/job/44693465469) runs as expected, namely:

* The job for the `esr` branch does not warn about new ESR version 140 because it finds the `esr-140` branch.
* The job for the `esr-140` branch exits early because there is no newer version available.

Unfortunately the duplication is "necessary" if we don't want to overhaul the test suite, as ./.github/scripts/extract-current-version.sh is relying on the ref of the given job.