### PR TITLE
BETA-CORE24 Bug 259356 - Force legacy behavior for XDG support on Snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,6 +41,7 @@ apps:
       SPEECHD_ADDRESS: "unix_socket:/run/user/$SNAP_UID/speech-dispatcher/speechd.sock"
       MOZ_DBUS_APP_NAME: "firefox_beta"
       MOZ_APP_REMOTINGNAME: "firefox_firefox"
+      MOZ_LEGACY_HOME: 1
     slots:
       - dbus-daemon
       - mpris


### PR DESCRIPTION
This is not saying bug 1902632 /
https://github.com/canonical/firefox-snap/pull/63 is wrong but rather that this requires upstream (gnome-sdk) changes and that because of how Snapd treats those directories (SNAP_USER_DATA/SNAP_USER_COMMON https://snapcraft.io/docs/environment-variables#heading--snap-user-common) there may be risks.

Addressing XDG support for Firefox is not as important when Snap is involved given the profile is already a subdirectory of the snap user's data under $HOME/snap/<snap-package>/..., so let's make use of the legacy behavior until all the upstream risks are well understood.