### PR TITLE
CI: Ignore major version number for new version check for ESRs.

### DIFF
--- a/.github/scripts/check-new-version.py
+++ b/.github/scripts/check-new-version.py
@@ -42,7 +42,18 @@ def get_latest_build(candidate):
     return int(builds[-1][:-1].split('build')[-1])
 
 
-def test_version(current_version, candidate):
+"""Return candidate if it is larger than current_version.
+
+If ignore_major is True, then the major version number is ignored in the check.
+Originally intended for ESR: We are more deliberate about which ESRs we
+really want, and we are always alerted in the mailing list about new major
+ESR numbers anyway.
+"""
+def test_version(current_version, candidate, ignore_major=False):
+    if ignore_major:
+        if candidate.split('.')[0] > current_version.split('.')[0]:
+            return None
+
     # Drop the "esr" suffix from the candidate, since version.parse
     # only supports versions that follow the PEP 440 requirements.
     nv = version.parse(candidate.split("esr")[0])
@@ -75,7 +86,9 @@ def check_new_candidates(channel, current_version):
         if channel == RELEASE and \
            ("b" in candidate or candidate.endswith("esr")):
             continue
-        new_version = test_version(new_version, candidate) or new_version
+        ignore_major = "esr" in current_version
+        new_version = test_version(new_version, candidate, ignore_major) or \
+                      new_version
     if new_version != current_version:
         logging.info("new version: {} > {}"
                      .format(new_version, current_version))

--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -85,15 +85,6 @@ jobs:
             git config user.email "actions@github.com"
             git commit -m "Bump version to the latest ESR release (${{ env.new_version }})."
             git push
-          # Only warn about new ESR major version if such an esr-{version} branch does not exist
-          elif ! git show-ref "esr-$new_esr_major_version"; then
-            # We don't want this spamming the Mattermost channel, so just allow
-            # it to send messages between 10:00 and 11:00.
-            if [ "$(date +%H)" = 10 ]; then
-              echo "New major version (${{ env.new_version }}), please proceed to a manual update."
-              mm_notification=$(printf '{"text": "Merge new major ESR Firefox version: %s"}' ${{ env.new_version }})
-              curl -s -i -X POST -H 'Content-Type: application/json' -d "$mm_notification" "${{ secrets.MM_URL }}"
-            fi
           fi
   check-new-beta:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Sample runs:

### ESR 
New major releases are not reported for ESR branches:

```
% ./check-new-version.py esr 140.1.0esr-1
% ./check-new-version.py esr 140.0.0esr-1
INFO:root:new version: 140.1.0esr-1 > 140.0.0esr-1
140.1.0esr-1
% ./check-new-version.py esr 128.13.0esr-1
% ./check-new-version.py esr 128.12.0esr-1
INFO:root:new version: 128.13.0esr-1 > 128.12.0esr-1
128.13.0esr-1
```

### Others

New major releases are still reported for non-ESR branches:
```
% ./check-new-version.py beta 141.0b9-1
% ./check-new-version.py beta 140.0b9-1
INFO:root:new version: 141.0b9-1 > 140.0b9-1
141.0b9-1
```