### PR TITLE
[STABLE] Retry downloads of the LLVM tarball.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -186,7 +186,18 @@ parts:
       elif [ $CRAFT_TARGET_ARCH = "arm64" ]; then
         BINARIES_SUFFIX=aarch64-linux-gnu.tar.xz
       fi
-      wget -O - $ROOT/$BINARIES_BASENAME-$BINARIES_SUFFIX | tar -x --xz
+
+      # Github introduced a time-out that causes this pull to fail in ARMv8
+      # Launchpad builders. Use -c to continue a failed pull. Give up after
+      # 6 attempts.
+      i=0
+      until wget -cO llvm.tar.xz $ROOT/$BINARIES_BASENAME-$BINARIES_SUFFIX; do
+        i=$((i+1))
+        test [ "$i" = 6 ] && exit 53
+      done
+      tar -xf llvm.tar.xz
+      rm llvm.tar.xz
+
       # And cmake-$LLVM_RELEASE.src needed on LLVM >= 15.0.0
       wget -O - $ROOT/cmake-$LLVM_RELEASE.src.tar.xz | tar -x --xz
       mv cmake-$LLVM_RELEASE.src cmake


### PR DESCRIPTION
Github introduced a time-out that causes this pull to fail in ARMv8 Launchpad builders. Use -c to continue a failed pull. Give up after 6 attempts.

Attempted build: https://launchpad.net/~nteodosio/+snap/ff-wget-bails/+build/2874392"