### PR TITLE
CI: Use a Canonical e-mail address for the robot.

### DIFF
--- a/.github/workflows/bump-beta-rust-version.yml
+++ b/.github/workflows/bump-beta-rust-version.yml
@@ -40,8 +40,8 @@ jobs:
           if $(dpkg --compare-versions $CURRENT lt $NEW); then
             sed -i "s/\(REQUIRED_RUST_VERSION=\)$CURRENT/\1$NEW/" snapcraft.yaml
             git add snapcraft.yaml
-            git config user.name "GitHub Actions"
-            git config user.email "actions@github.com"
+            git config user.name "Canonical Github Actions"
+            git config user.email "actions@canonical.com"
             git commit -m "Bump rust requirement ($NEW)."
             git push https://${{ github.actor }}:${{ secrets.REPO_TOKEN }}@github.com/${{ github.repository }}.git beta
           fi

--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -42,8 +42,8 @@ jobs:
           if [ $(echo ${{ env.current_version }} | cut -d. -f1) = $(echo ${{ env.new_version }} | cut -d. -f1) ]; then
             sed -i "s/^version: \"\(.*\)\"$/version: \"${{ env.new_version }}\"/" snapcraft.yaml
             git add snapcraft.yaml
-            git config user.name "GitHub Actions"
-            git config user.email "actions@github.com"
+            git config user.name "Canonical Github Actions"
+            git config user.email "actions@canonical.com"
             git commit -m "Bump version to the latest release candidate (${{ env.new_version }})."
             git push
           else


### PR DESCRIPTION
The cla-check started failing on actions@github.com, so change it to a canonical.com e-mail address, even if fictitious.

The robot was then able to bump the version appropriatedly as per https://github.com/nteodosio/firefox-snap/commits/stable/.