### PR TITLE
LLVM 17

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -175,7 +175,7 @@ parts:
       - make
       - wget
     build-environment:
-      - LLVM_RELEASE: "16.0.4"
+      - LLVM_RELEASE: "17.0.6"
     override-pull: |
       ROOT=https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_RELEASE
       # Download the binaries


### PR DESCRIPTION
```
::  0:02.29 ERROR: Only clang/llvm 17.0 or newer is supported (found version 16.0.4).
```
https://launchpadlibrarian.net/818159065/buildlog_snap_ubuntu_jammy_arm64_firefox-snap-beta_BUILDING.txt.gz