### PR TITLE
[STABLE] Disable build parallelism in ARMHF.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -444,7 +444,11 @@ parts:
         # xvfb is only needed when doing a PGO-enabled build
         xvfb-run '--server-args=-screen 0 1920x1080x24' $MACH build -j$CRAFT_PARALLEL_BUILD_COUNT
       else
-        $MACH build -j$CRAFT_PARALLEL_BUILD_COUNT
+        if [ $CRAFT_TARGET_ARCH = "armhf" ]; then
+          $MACH build -j1
+        else
+          $MACH build -j$CRAFT_PARALLEL_BUILD_COUNT
+        fi
       fi
       if [ $BUILD_DBGSYMS = "true" ]; then
         DUMP_SYMS=$CRAFT_STAGE/usr/bin/dump_syms $MACH buildsymbols


### PR DESCRIPTION
Firefox failed to build on ARMHF with

```
:: 34:38.26 error: failed to mmap file '/build/firefox/parts/firefox/build/obj-armv7l-unknown-linux-gnueabihf/armv7-unknown-linux-gnueabihf/release/deps/libstyle-2b1023e411b53762.rlib': Cannot allocate memory (os error 12)
:: 34:38.65 error: could not compile `gkrust` (lib) due to 1 previous error
```

If we merge it, I suggest that I propagate the change to beta, nightly, beta-core24, stable-core24, even though it didn't happen there yet, for consistency's sake.