### PR TITLE
Revert "Edge channel of the Gnome SDK only for Risc-V."

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -276,10 +276,6 @@ parts:
       ln -sf "/usr/bin/cargo-${rustv}" "$unvBinDir/cargo"
 
       cargo install cbindgen
-      # Needed until the Gnome SDK is promoted to stable for RISC-V.
-      if [ $CRAFT_ARCH_BUILD_FOR = "riscv64" ]; then
-        snap refresh --edge gnome-46-2404-sdk
-      fi
 
       QUILT_PATCHES=$CRAFT_PROJECT_DIR/patches quilt push -a
       BUILD_DBGSYMS=false


### PR DESCRIPTION
This reverts commit 80c955fe059f038d97a0d7e2bb3aed6c6f359231, as the edge builds of Gnome-46-2404{,-sdk} have been promoted to stable.