### PR TITLE
CI: Bump versions of stable-core24 and beta-core24 too.

### DIFF
--- a/.github/workflows/new-version-check.yml
+++ b/.github/workflows/new-version-check.yml
@@ -23,10 +23,13 @@ on:
 jobs:
   check-new-stable:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        stable-branch: [stable, stable-core24]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: stable
+          ref: ${{matrix.stable-branch}}
       - name: Extract current version
         run: ./.github/scripts/extract-current-version.sh
       - name: Install python deps
@@ -88,10 +91,13 @@ jobs:
           fi
   check-new-beta:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        beta-branch: [beta, beta-core24]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: beta
+          ref: ${{matrix.beta-branch}}
       - name: Extract current version
         run: ./.github/scripts/extract-current-version.sh
       - name: Install python deps


### PR DESCRIPTION
Confirmed working in my namespace by commiting this to stable, reverting the latest release of each of {stable, stable-core24, beta, beta-core24}, and then kicking of the "new version check workflow", which caused each branch to be bumped correctly as per:

* https://github.com/nteodosio/firefox-snap/commits/stable
* https://github.com/nteodosio/firefox-snap/commits/stable-core24
* https://github.com/nteodosio/firefox-snap/commits/beta
* https://github.com/nteodosio/firefox-snap/commits/beta-core24

