### PR TITLE
Reapply "Add kerberos-tickets plug."

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -83,6 +83,7 @@ apps:
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
+      - kerberos-tickets
       - login-session-observe
       - network
       - network-observe
@@ -115,6 +116,7 @@ apps:
       - host-hunspell
       - host-usr-share-hunspell
       - joystick
+      - kerberos-tickets
       - login-session-observe
       - network
       - network-observe


### PR DESCRIPTION
This reverts commit 673af70f9094ad227925d22b66fce139acd1af59.

The review-tools [bug](https://bugs.launchpad.net/review-tools/+bug/2123820) that was blocking it has been fixed. I confirmed it in Chromium so if this is OK, I'll cherry pick to all our active branches.