### PR TITLE
snap: add `system-observe` plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -89,6 +89,7 @@ apps:
       - pcscd
       - removable-media
       - screen-inhibit-control
+      - system-observe
       - system-packages-doc
       - timezone-control
       - u2f-devices


### PR DESCRIPTION
users can connect to this plug to get rid of this spamming https://discourse.ubuntu.com/t/apparmor-denying-firefox-polling-memory-pressure/73588?u=soumyadghosh