### PR TITLE
Declare host-usr-share-hunspell plug for install hook

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -572,3 +572,5 @@ slots:
 hooks:
   post-refresh:
     plugs: [host-usr-share-hunspell]
+  install:
+    plugs: [host-usr-share-hunspell]


### PR DESCRIPTION
Declares a missing plug for the install which despite being a symlink to post-refresh, still needs its own declaration. 
https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/2148711