### PR TITLE
Remove Vulkan and Mesa.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -531,8 +531,6 @@ parts:
       if [ $BUILD_DBGSYMS = "true" ]; then
         cp obj-*/dist/firefox-*.crashreporter-symbols.zip $CRAFT_STAGE/debug-symbols/
       fi
-      # update the path to the vulkan drivers for the snap environment
-      sed -i 's#/usr/lib/#/snap/firefox/current/usr/lib/#' $CRAFT_PART_INSTALL/usr/share/vulkan/icd.d/*.json
     override-stage: |
       # Workaround for LP: #2016358: create mount points for the gnome
       # content interface, while a proper fix is implemented in snapd.
@@ -550,9 +548,7 @@ parts:
           - libproxy1v5
           - libspa-0.2-modules
           - libspeechd2
-          - libvulkan1
           - libxt6t64
-          - mesa-vulkan-drivers
           - opensc-pkcs11
         - to arm64:
           - libasound2t64:arm64
@@ -563,9 +559,7 @@ parts:
           - libproxy1v5:arm64
           - libspa-0.2-modules:arm64
           - libspeechd2:arm64
-          - libvulkan1:arm64
           - libxt6t64:arm64
-          - mesa-vulkan-drivers:arm64
           - opensc-pkcs11:arm64
       - else:
         - libasound2t64
@@ -576,9 +570,7 @@ parts:
         - libproxy1v5
         - libspa-0.2-modules
         - libspeechd2
-        - libvulkan1
         - libxt6t64
-        - mesa-vulkan-drivers
         - opensc-pkcs11
       - pipewire-bin
       - pipewire-pulse
@@ -609,15 +601,12 @@ parts:
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libspeechd.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libssh.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libssl.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libVkLayer*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwind.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXt.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pipewire-*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/spa-*
       - usr/share/alsa
       - usr/share/pipewire
-      - usr/share/vulkan
       # Workaround for LP: #2016358 (see the 'override-stage' above).
       - gnome-platform
       - data-dir/icons


### PR DESCRIPTION
Fixes https://launchpad.net/bugs/2149810.

Vulkan and Mesa are provided via the mesa-2404 interface.

Preliminarily provided in the stable/no-mesa branch (from https://launchpad.net/~nteodosio/+snap/ff-no-mesa-no-vulkan), the fix was verified by @tjaalton.