### PR TITLE
[STABLE] Use client.conf for PipeWire configuration

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,7 +35,7 @@ apps:
       DICPATH: "$SNAP_COMMON/snap-hunspell"
       GTK_USE_PORTAL: 1
       HOME: "$SNAP_USER_COMMON"
-      PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"
+      PIPEWIRE_CONFIG_NAME: client.conf
       PIPEWIRE_MODULE_DIR: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pipewire-0.3"
       SPA_PLUGIN_DIR: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/spa-0.2"
       SPEECHD_ADDRESS: "unix_socket:/run/user/$SNAP_UID/speech-dispatcher/speechd.sock"


### PR DESCRIPTION
The PIPEWIRE_CONFIG_NAME env var was set to pipewire.conf (the daemon config), which caused Firefox's embedded libpipewire to load the full daemon module set and bind listening sockets on pipewire-0 and pipewire-0-manager in-process. This accidentally worked for a single WebRTC stream because the in-process "daemon" could serve itself, but a second pw_context_new call (e.g. camera + screenshare) failed: module-protocol-native could not acquire
$XDG_RUNTIME_DIR/pipewire-0.lock, which the first context still held, and aborted with "Resource temporarily unavailable (maybe another daemon is running)".

Switch to client.conf, which loads module-protocol-native without socket args and correctly acts as a pure client.

Reproducer (requires media.webrtc.camera.allow-pipewire and media.webrtc.capture.allow-pipewire set to true in about:config):
  1. Open https://www.webrtc-experiment.com/RecordRTC/ and start a camera stream.
  2. Open https://www.webrtc-experiment.com/Pluginfree-Screen-Sharing/ and start a screenshare; it fails to load.

A follow-up commit should probably remove the PW server configuration files, and the PW binaries, since FF has no use for them.

Reported by Alessandro Astone.