### PR TITLE
[NIGHTLY] Bundle Kerberos that ignores a failed includedir.

### DIFF
--- a/patches/external/krb5:ignore-failed-includedirs
+++ b/patches/external/krb5:ignore-failed-includedirs
@@ -1,0 +1,42 @@
+Description: Ignore non-existent includedirs instead of bailing out.
+ .
+ The snap sandbox does not contain /var/lib/ which is a default includedir
+ in sssd-krb5.
+ .
+Author: Nathan Pratta Teodosio <nteodosio@ubuntu.com>
+Bug-Ubuntu: https://launchpad.net/bugs/2122317
+
+--- krb5/src/util/profile/prof_parse.c
++++ krb5/src/util/profile/prof_parse.c
+@@ -254,7 +254,10 @@ static errcode_t parse_include_dir(const
+     errcode_t retval = 0;
+     char **fnames, *pathname;
+     int i;
+-
++    char *snap_ok_dir = "/etc/krb5.conf.d";
++    if (strncmp(dirname, snap_ok_dir, strlen(snap_ok_dir)) != 0) {
++        return 0;
++    }
+     if (k5_dir_filenames(dirname, &fnames) != 0)
+         return PROF_FAIL_INCLUDE_DIR;
+ 
+
+The change causes the profile-related tests to understandably fail.
+We do not need to worry about the tests as we're pulling Kerberos packages
+from the Ubuntu archive, which already carries the tests out.
+
+--- krb5/debian/rules
++++ krb5/debian/rules
+@@ -52,5 +52,4 @@
+ # Build the documentation in a separate directory, since otherwise we'll
+ # overwrite the info pages provided upstream and then debian/rules clean won't
+-build-indep: build-indep-stamp
+ # build-indep should not need to depend on build-arch, but currently it does at least to populate build/doc
+ # Add the dependency until we get a chance to make it work properly
+@@ -148,5 +148,5 @@
+ 
+ override_dh_auto_test:
+-	dh_auto_test $(DH_BUILD_OPTS) --no-parallel
++	:
+ 
+ %:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -554,13 +554,11 @@ parts:
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/opensc-pkcs11.so
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkcs11/opensc-pkcs11.so
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasn1.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgssapi.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhcrypto.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libheimbase.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libheimntlm.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhogweed.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhx509.so.*
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libkrb5.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/liblber-2.4.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libldap_r-2.4.so.*
       - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnettle.so.*
@@ -601,6 +599,38 @@ parts:
         mkdir $INSTALLDIR/locale-$LANGCODE
         cp $XPI $INSTALLDIR/locale-$LANGCODE/langpack-$LANGCODE@firefox.mozilla.org.xpi
       done
+
+  # Bundle patched Kerberos library that ignores failed includedirs (LP:2122317)
+  #
+  # We need to untangle this part from Gnome extension's idiosyncrasies,
+  # as they cause cryptic errors including but not limited to
+  #
+  # > relocation R_X86_64_TPOFF32 against `buffer' can not be used when making
+  # > a shared object; recompile with -fPIC"
+  kerberos:
+    plugin: nil
+    build-packages:
+      - ubuntu-dev-tools
+      - python3-lxml # Missing from Krb5 build-dependencies?
+    build-environment:
+      - DEB_BUILD_OPTIONS: nodoc
+      # Delete Gnome extension's injections in this variable
+      - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/share/pkgconfig
+    override-build: |
+      # Delete Gnome extension's injections in this variable
+      export PATH=${PATH#/snap*:}
+
+      # Fetch, patch and build Kerberos
+      releasePocket=$(lsb_release -c | cut -f2)
+      pull-lp-source krb5 "$releasePocket"
+      cd krb5*/
+      apt build-dep -y .
+      patch -p1 < "$CRAFT_PROJECT_DIR/patches/external/krb5:ignore-failed-includedirs"
+      ./debian/rules build
+
+      # Prime its resultant relevant libraries
+      mkdir -p "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR"
+      cp -d build/lib/*krb5*.so* "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR"
 
   launcher:
     plugin: nil


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2122317